### PR TITLE
Update export_dae.py

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -639,7 +639,8 @@ class DaeExporter:
             bm.free()
 
         #mesh.update(calc_tessface=True)# 2.79
-        mesh.update(calc_edges=False, calc_edges_loose=False, calc_loop_triangles=True)# 2.80
+        #mesh.update(calc_edges=False, calc_edges_loose=False, calc_loop_triangles=True)# 2.80
+        mesh.update(calc_edges=False, calc_edges_loose=False)# 2.81
         vertices = []
         vertex_map = {}
         surface_indices = {}


### PR DESCRIPTION
This is a quite small change, but in the new blender version 2.81 it seems that the function parameter calc_loop_triangles=True in the mesh.update method has been dropped.